### PR TITLE
Add coreutils to PATH in colorscad.sh to fix many issues on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This script requires the Bash shell, and of course OpenSCAD.
 AMF export should work with OpenSCAD version 2015.03, but was mostly tested on 2019.05.
 3MF export requires version 2019.05 or newer, and also requires some preparation steps (compilation).
 
-Platform-wise, it should run anywhere Bash runs (that includes i.e. cygwin).
+Platform-wise, it should run anywhere Bash runs (that includes i.e. cygwin) as long as GNU utilities are available on the path (macOS users should `brew install coreutils`).
 No assumptions are made about OS-specific directories, such as /tmp/ and the like.
 The platform-native OpenSCAD binary does have to be reachable via the PATH,
 which means on Windows users may need to first run something like:

--- a/colorscad.sh
+++ b/colorscad.sh
@@ -3,6 +3,11 @@ INPUT=$1
 OUTPUT=$2
 PARALLEL_JOB_LIMIT=${3:-8}
 
+if [ "$(uname)" = Darwin ]; then
+	# Add GNU coreutils to the path for macOS users (`brew install coreutils`).
+	PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
+fi
+
 if [ -z "$OUTPUT" ]; then
 	echo "Usage: $0 <input scad file> <output file> [MAX_PARALLEL_JOBS]"
 	echo "The output file must not yet exist, and must have as extension either '.amf' or '.3mf'."


### PR DESCRIPTION
Command arguments being used for `mktemp` and `sed` aren't compatible with the default macOS versions. We can automatically search the coreutils path and suggest that users install it from the README on macOS.

The script will still fail due to arguments to `wait` but that's a separate issue.