### PR TITLE
Fix failing tests with openscad >=2024.1.26 linked against lib3mf v2

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -132,7 +132,7 @@ function test_render {
 	# Generate output
 	local OUTPUT="${TEMPDIR}/output.${FORMAT}"
 	rm -f "$OUTPUT"
-	# OpenSCAD >= 2024.01.26 requires enabling "predictible-output" to get the same behavior as older versions
+	# OpenSCAD >= 2024.01.26 with lib3mf v2 requires enabling "predictible-output" to get the same behavior as older versions
 	if openscad --help 2>&1 | grep -q predictible-output; then
 		function openscad { command openscad --enable=predictible-output "$@"; }; export -f openscad
 	fi


### PR DESCRIPTION
On OpenSCAD versions >= 2024.01.26, when linked to lib3mf v2, parameter `--enable=predictible-output` needs to be added to get the same output as on older versions. For the upstream binaries, this only affects macos nightly.
To fix, just enable the parameter whenever it's supported.