### PR TITLE
ci(MacOS): support /Volumes/OpenSCAD/OpenSCAD*.app in mounted .dmg

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
           aria2c "${URI}" -o openscad.dmg
           hdiutil attach openscad.dmg
-          echo /Volumes/OpenSCAD/OpenSCAD.app/Contents/MacOS >> "$GITHUB_PATH"
+          echo /Volumes/OpenSCAD/OpenSCAD*.app/Contents/MacOS >> "$GITHUB_PATH"
         working-directory: ${{ runner.temp }}
 
       - name: Install OpenSCAD (zip)


### PR DESCRIPTION
As of 24 nov 2024, the 2021.01 image puts OpenSCAD in 'OpenSCAD-2021.01.app', instead of just 'OpenSCAD.app'.