### PR TITLE
Update colorscad.sh to allow path to openscad program

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Both colorscad and 3mfmerge changes are included here. Unless explicitly mention
 
 ## [Unreleased]
 
+### Added
+
+- Support using OpenSCAD binaries which are not called `openscad`, via env var `OPENSCAD_CMD` (thanks: pinkfish)
+
 ## [0.5.2] - 2024-09-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -15,13 +15,19 @@ AMF export should work with OpenSCAD version 2015.03, but was mostly tested on 2
 Platform-wise, it should run anywhere Bash runs (that includes i.e. cygwin).
 No assumptions are made about OS-specific directories, such as /tmp/ and the like.
 
-The platform-native OpenSCAD binary does need to be reachable via the PATH,
-which means on Windows Cygwin users may need to first run something like:<br>
+The platform-native OpenSCAD binary needs to be available for this script to work.
+If it is called `openscad` and available on the PATH, then it should work out-of-the-box.
+
+In case the binary has a strange name, then set environment variable `OPENSCAD_CMD` to its name.
+This may be a full path, or just the name.
+
+Unless `OPENSCAD_CMD` is set to a full path, the binary needs to be reachable via the PATH.
+On Windows Cygwin users may need to first run something like:<br>
 ```export PATH=/cygdrive/c/Program\ Files/OpenSCAD:$PATH```<br>
 Similarly, Mac users can try:<br>
 ```export PATH=/Applications/OpenSCAD.app/Contents/MacOS:$PATH```
 
-It should mostly work on Bash 3 (i.e. Mac's non-Homebrew default), although for best results Bash 4 is recommended.
+This script should mostly work on Bash 3 (i.e. Mac's non-Homebrew default), although for best results Bash 4 is recommended.
 
 Usage
 -----

--- a/colorscad.sh
+++ b/colorscad.sh
@@ -126,14 +126,14 @@ if [ "$FORMAT" != amf ] && [ "$FORMAT" != 3mf ]; then
 	exit 1
 fi
 
-if ! command -v ${OPENSCAD_CMD} &> /dev/null; then
-	echo "Error: $OPENSCAD_CMD command not found! Make sure it's in your PATH."
+if ! command -v "$OPENSCAD_CMD" &> /dev/null; then
+	echo "Error: ${OPENSCAD_CMD} command not found! Make sure it's in your PATH."
 	exit 1
 fi
 
 if [ "$FORMAT" = 3mf ]; then
 	# Check if openscad was built with 3mf support
-	if ! ${OPENSCAD_CMD} --info 2>&1 | grep '^lib3mf version: ' | grep -qv 'not enabled'; then
+	if ! "$OPENSCAD_CMD" --info 2>&1 | grep '^lib3mf version: ' | grep -qv 'not enabled'; then
 		echo "Warning: your openscad version does not seem to have 3MF support, see 'openscad --info'."
 		echo "Either update it, or use AMF output."
 		echo
@@ -175,7 +175,7 @@ TEMPDIR=$(mktemp -d ./tmp.XXXXXX)
 trap "rm -Rf '$(pwd)/${INPUT_CSG}' '$(pwd)/${TEMPDIR}'" EXIT
 
 # Convert input to a .csg file, mainly to resolve named colors. Also to evaluate functions etc. only once.
-${OPENSCAD_CMD} "$INPUT" -o "$INPUT_CSG" "${OPENSCAD_EXTRA[@]}"
+"$OPENSCAD_CMD" "$INPUT" -o "$INPUT_CSG" "${OPENSCAD_EXTRA[@]}"
 
 if ! [ -s "$INPUT_CSG" ]; then
 	echo "Error: the produced file '$INPUT_CSG' is empty. Looks like something went wrong..."
@@ -190,7 +190,7 @@ echo "Get list of used colors"
 # means more geometry; we want to start the biggest jobs first to improve parallelism.
 COLOR_ID_TAG="colorid_$$_${RANDOM}"
 COLORS=$(
-	${OPENSCAD_CMD} "$INPUT_CSG" -o "${TEMPDIR}/no_color.stl" -D "module color(c) {echo(${COLOR_ID_TAG}=str(c));}" 2>&1 |
+	"$OPENSCAD_CMD" "$INPUT_CSG" -o "${TEMPDIR}/no_color.stl" -D "module color(c) {echo(${COLOR_ID_TAG}=str(c));}" 2>&1 |
 	tr -d '\r"' |
 	sed -n "s/^ECHO: ${COLOR_ID_TAG} = // p" |
 	sort |
@@ -247,7 +247,7 @@ function render_color {
 		if [ $VERBOSE -ne 1 ]; then
 			EXTRA_ARGS=--quiet
 		fi
-		${OPENSCAD_CMD} "$INPUT_CSG" -o "$OUT_FILE" $EXTRA_ARGS -D "\$colored = false; module color(c) {if (\$colored) {children();} else {\$colored = true; if (str(c) == \"${COLOR}\") children();}}"
+		"$OPENSCAD_CMD" "$INPUT_CSG" -o "$OUT_FILE" $EXTRA_ARGS -D "\$colored = false; module color(c) {if (\$colored) {children();} else {\$colored = true; if (str(c) == \"${COLOR}\") children();}}"
 		if [ -s "$OUT_FILE" ]; then
 			echo "Finished at ${OUT_FILE}"
 		else

--- a/colorscad.sh
+++ b/colorscad.sh
@@ -19,21 +19,23 @@ Options
   -j  Maximum number of parallel jobs to use: defaults to 8, reduce if you're low on RAM
   -o  Output file: it must not yet exist (unless option -f is used),
       and must have as extension either '.amf' or '.3mf'
-  -p  The path to the openscad binary to use
   -v  Verbose logging: mostly, this enables the OpenSCAD rendering stats output (default disabled)
+
+Environment variables
+  OPENSCAD_CMD  The name of the openscad binary to use, may include full path (default: 'openscad')
 
 Example which also includes some openscad options at the end:
   $0 -i input.scad -o output.3mf -f -j 4 -- -D 'var="some value"' --hardwarnings
 EOF
 }
 
+
 FORCE=0
 INPUT=
 OUTPUT=
 PARALLEL_JOB_LIMIT=8
 VERBOSE=0
-OPENSCAD_CMD=openscad
-while getopts :fhi:j:o:p:v opt; do
+while getopts :fhi:j:o:v opt; do
 	case "$opt" in
 		f)
 			FORCE=1;
@@ -59,9 +61,6 @@ while getopts :fhi:j:o:p:v opt; do
 			fi
 			OUTPUT="$OPTARG"
 		;;
-		p)
-		  OPENSCAD_CMD="$OPTARG"
-		;;  
 		v)
 			VERBOSE=1
 		;;
@@ -74,6 +73,11 @@ done
 # Assign all parameters beyond '--' to OPENSCAD_EXTRA
 shift "$((OPTIND-1))"
 OPENSCAD_EXTRA=("$@")
+
+if [ -n "$OPENSCAD_CMD" ]; then
+	echo "OpenSCAD binary in use: $(command -v "$OPENSCAD_CMD")"
+fi
+: "${OPENSCAD_CMD=openscad}"
 
 if [ "$(uname)" = Darwin ]; then
 	# BSD sed, as used on macOS, uses a different parameter than GNU sed to enable line-buffered mode


### PR DESCRIPTION
Add in a way to set the path for openscad, so it can be overriden in scripts and works on the mac where the capitalization is different.