### PR TITLE
Make it possible to run cmake from toplevel directory

### DIFF
--- a/3mfmerge/CMakeLists.txt
+++ b/3mfmerge/CMakeLists.txt
@@ -4,8 +4,8 @@ project(3mfmerge)
 
 # The generator expression $<0:> at the end, is only there to prevent multi-config generators such
 # as MSVC's nmake from adding 'Debug' and the like
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/bin$<0:>)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/bin$<0:>)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin$<0:>)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin$<0:>)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -14,7 +14,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 include(FetchContent)
 set(FETCHCONTENT_QUIET FALSE)
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 find_package(LIB3MF 2)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.14...3.28)
+
+project(colorscad)
+add_subdirectory(3mfmerge)
+
+install(PROGRAMS colorscad.sh RENAME colorscad DESTINATION bin)


### PR DESCRIPTION
Makes it more clean and easier to install all needed files.

Before:
```
%build
pushd 3mfmerge
%cmake
%cmake_build
popd

%install
install -p -D -m 0755 colorscad.sh %{buildroot}%{_bindir}/colorscad
pushd 3mfmerge
%cmake_install
popd
```

After:
```
%build
%cmake
%cmake_build

%install
%cmake_install
```