### PR TITLE
fix: update lib3mf to v2.4.1

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -196,10 +196,7 @@ jobs:
           mkdir build
           cd build
           cmake .. -DLIB3MF_TESTS=OFF
-          # Limit workers to 2 for macos, as GHA's macos runner gets overloaded and very slow otherwise
-          WORKERS=
-          if [[ "$(uname -s)" = Darwin ]]; then WORKERS=2; fi
-          cmake --build . --parallel ${WORKERS}
+          cmake --build . --parallel $(getconf _NPROCESSORS_ONLN)
           # Meanwhile let's also verify the "install" step works; installed files aren't actually used further on here
           cmake --install . || sudo cmake --install .
         working-directory: 3mfmerge

--- a/3mfmerge/cmake/FindLIB3MF.cmake
+++ b/3mfmerge/cmake/FindLIB3MF.cmake
@@ -44,11 +44,16 @@ else()
   unset(LIB3MF_INCLUDE_DIRS)
   unset(LIB3MF_LIBRARIES)
 
+  set(PATCHES
+    ${CMAKE_CURRENT_SOURCE_DIR}/patches/lib3mf_static.patch
+    ${CMAKE_CURRENT_SOURCE_DIR}/patches/lib3mf_missing_include.patch
+  )
+
   FetchContent_Declare(
     lib3mf
     URL https://github.com/3MFConsortium/lib3mf/releases/download/v${LIB3MF_VERSION}/lib3mf-${LIB3MF_VERSION}-source-with-submodules.zip
     URL_HASH SHA256=${LIB3MF_SOURCES_HASH}
-    PATCH_COMMAND git apply --ignore-whitespace ${CMAKE_CURRENT_SOURCE_DIR}/patches/lib3mf_static.patch
+    PATCH_COMMAND git apply --ignore-whitespace ${PATCHES}
     EXCLUDE_FROM_ALL
   )
   # LIB3MF still uses "cmake_minimum_required (VERSION 3.0)", which is unsupported in CMake 4.0

--- a/3mfmerge/cmake/FindLIB3MF.cmake
+++ b/3mfmerge/cmake/FindLIB3MF.cmake
@@ -37,9 +37,8 @@ if(LIB3MF_FOUND AND NOT TARGET lib3mf)
     INTERFACE_INCLUDE_DIRECTORIES "${LIB3MF_INCLUDE_DIRS}"
   )
 else()
-  set(LIB3MF_VERSION 2.2.0)
-  set(LIB3MF_TARBALL_HASH 96e85e278fc5474123e3c47237dd42faaf1fdf8e182541a84af7fe84ddd3cbde)
-
+  set(LIB3MF_VERSION 2.4.1)
+  set(LIB3MF_SOURCES_HASH 4e9e1776f4dd1b3dfce684ce9bb4ad1157dadf29908a1f3aabb6cd4358bf3248)
   message("Building LIB3MF ${LIB3MF_VERSION} from source")
 
   unset(LIB3MF_INCLUDE_DIRS)
@@ -47,13 +46,11 @@ else()
 
   FetchContent_Declare(
     lib3mf
-    URL https://github.com/3MFConsortium/lib3mf/archive/refs/tags/v${LIB3MF_VERSION}.tar.gz
-    URL_HASH SHA256=${LIB3MF_TARBALL_HASH}
+    URL https://github.com/3MFConsortium/lib3mf/releases/download/v${LIB3MF_VERSION}/lib3mf-${LIB3MF_VERSION}-source-with-submodules.zip
+    URL_HASH SHA256=${LIB3MF_SOURCES_HASH}
     PATCH_COMMAND git apply --ignore-whitespace ${CMAKE_CURRENT_SOURCE_DIR}/patches/lib3mf_static.patch
     EXCLUDE_FROM_ALL
   )
-  # LIB3MF's tests reference submodule dependencies, not included in the tarball
-  option(LIB3MF_TESTS OFF)
   # LIB3MF still uses "cmake_minimum_required (VERSION 3.0)", which is unsupported in CMake 4.0
   set(CMAKE_POLICY_VERSION_MINIMUM 3.5)
 

--- a/3mfmerge/patches/lib3mf_missing_include.patch
+++ b/3mfmerge/patches/lib3mf_missing_include.patch
@@ -1,0 +1,11 @@
+--- a/Source/Model/Writer/v100/NMR_ResourceDependencySorter.cpp	2025-09-04 17:58:45.035566911 +0000
++++ b/Source/Model/Writer/v100/NMR_ResourceDependencySorter.cpp	2025-09-04 17:59:45.035566911 +0000
+@@ -32,6 +32,8 @@
+ 
+ #include "Model/Writer/v100/NMR_ResourceDependencySorter.h"
+ 
++#include <algorithm>
++
+ #include "Common/Graph/DirectedGraph.h"
+ #include "Common/Graph/GraphAlgorithms.h"
+ #include "Model/Classes/NMR_Model.h"

--- a/test/run.sh
+++ b/test/run.sh
@@ -92,7 +92,7 @@ function fail_tips {
 trap 'echo "Failure at $0:$LINENO" >&2; fail_tips >&2' ERR
 
 
-# Prepare given 3MF for comparison: strip UUIDs, and remove the "xmlns" attribute that not all versions add.
+# Prepare given 3MF for comparison: strip UUIDs, and remove the "xmlns:*" attributes that not all versions add.
 function canonicalize_3mf {
 	local IN=$1
 	local OUT_DIR=$2
@@ -100,9 +100,9 @@ function canonicalize_3mf {
 	unzip -q "$IN" -d "$OUT_DIR"
 
 	# Need to specify backup suffix for macOS compatibility; just remove unneeded backup
-	sed -i.bak '
+	sed -E -i.bak '
 		s/UUID="[^"]*"//g;
-		s/ xmlns:sc="[^"]*"//g;
+		s/ xmlns:[a-z]+="[^"]*"//g;
 	' "${OUT_DIR}/3D/3dmodel.model"
 	rm "${OUT_DIR}/3D/3dmodel.model.bak"
 }


### PR DESCRIPTION
This update fixes build failures on macos 15.5 (and possibly others), when lib3mf needs to be built from source via FetchContent.

Also includes a few other fixes, necessary to have a green build.